### PR TITLE
Add Splitbee links across all html pages

### DIFF
--- a/web/pages/api/index.html
+++ b/web/pages/api/index.html
@@ -79,6 +79,7 @@
     <link hreflang="en-us" rel="canonical" href="https://hashable.space" />
     <script src="https://unpkg.com/feather-icons"></script>
     <script src="https://cdn.jsdelivr.net/npm/axios/dist/axios.min.js"></script>
+    <script async src="https://cdn.splitbee.io/sb.js"></script>
   </head>
   <body>
     <nav id="main-nav">

--- a/web/pages/editor.html
+++ b/web/pages/editor.html
@@ -75,6 +75,7 @@
     <link hreflang="en-us" rel="canonical" href="https://hashable.space" />
     <script src="https://unpkg.com/feather-icons"></script>
     <script src="https://cdn.jsdelivr.net/npm/axios/dist/axios.min.js"></script>
+    <script async src="https://cdn.splitbee.io/sb.js"></script>
   </head>
   <body>
     <button class="back-to-home">

--- a/web/pages/playground.html
+++ b/web/pages/playground.html
@@ -74,6 +74,7 @@
 
     <link hreflang="en-us" rel="canonical" href="https://hashable.space" />
     <script src="https://unpkg.com/feather-icons"></script>
+    <script async src="https://cdn.splitbee.io/sb.js"></script>
   </head>
   <body>
     <div class="loader-container">


### PR DESCRIPTION
The PR #9 didn't so add split bee links all over the website.
Which prevents from collecting viewers from other pages rather than home.

Reference Issue:
- #8.

Commits 📈: 
- e901f2ac8ef025a41382ec32691d1f21afdbe1a2

Breaking Changes ⚠️:
- This PR adds @splitbee analytics throughout the website.