### PR TITLE
Adjust `Header` layout according to device width

### DIFF
--- a/web/src/components/Header.tsx
+++ b/web/src/components/Header.tsx
@@ -6,25 +6,48 @@ const Logo: Component = () => (
   <img class="h-10" src={LogoImage} alt="logo of hashable" />
 );
 
+const MobileNav: Component = () => (
+  <nav class="flex pt-5 sm:hidden flex-col">
+    <span class="my-1 text-md text-slate-500 font-medium hover:text-slate-600">
+      <Link href="/learn">Learn</Link>
+    </span>
+    <span class="my-1 text-md text-slate-500 font-medium hover:text-slate-600">
+      <Link href="/docs/intro">Documentation</Link>
+    </span>
+    <span class="my-1 text-md text-slate-500 font-medium hover:text-slate-600">
+      <Link href="/play">Playground</Link>
+    </span>
+  </nav>
+);
+
+const DefaultNav: Component = () => (
+  <nav class="hidden sm:block">
+    <span class="mx-3 text-sm text-slate-500 font-medium hover:text-slate-600">
+      <Link href="/learn">Learn</Link>
+    </span>
+    <span class="mx-3 text-sm text-slate-500 font-medium hover:text-slate-600">
+      <Link href="/docs/intro">Documentation</Link>
+    </span>
+    <span class="mx-3 text-sm text-slate-500 font-medium hover:text-slate-600">
+      <Link href="/play">Playground</Link>
+    </span>
+  </nav>
+);
+
 const Header: Component = () => (
-  <header class="w-full min-h-10 flex items-center justify-between py-5 px-5 ring-1 ring-slate-100">
+  <header class="w-full min-h-10 flex flex-col sm:flex-row items-start sm:items-center justify-between py-5 px-5 ring-1 ring-slate-100">
     <Link href="/">
       <span class="flex flex-row items-center">
         <Logo />
         <h2 class="ml-3 text-xl text-slate-800 font-semibold">Hashable</h2>
       </span>
     </Link>
-    <nav>
-      <span class="mx-3 text-sm text-slate-500 font-medium hover:text-slate-600">
-        <Link href="/learn">Learn</Link>
-      </span>
-      <span class="mx-3 text-sm text-slate-500 font-medium hover:text-slate-600">
-        <Link href="/docs/intro">Documentation</Link>
-      </span>
-      <span class="mx-3 text-sm text-slate-500 font-medium hover:text-slate-600">
-        <Link href="/play">Playground</Link>
-      </span>
-    </nav>
+
+    <div>
+      <MobileNav />
+
+      <DefaultNav />
+    </div>
   </header>
 );
 


### PR DESCRIPTION
Fixes responsiveness of the Header on mobile devices.

### Previously
<img width="366" alt="Screenshot 2022-07-08 at 8 36 33 PM" src="https://user-images.githubusercontent.com/72091386/178019610-8cec8ffa-e91f-4ada-ae63-3549bdcaf5ce.png">
 
### PR Change
<img width="337" alt="Screenshot 2022-07-08 at 8 37 02 PM" src="https://user-images.githubusercontent.com/72091386/178019715-eba35130-f226-47ac-9723-57fbf7df2fc1.png">

